### PR TITLE
Added an include for the boost threading stuff.

### DIFF
--- a/cob_people_detection/common/src/face_recognizer.cpp
+++ b/cob_people_detection/common/src/face_recognizer.cpp
@@ -77,7 +77,7 @@
 // boost
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/convenience.hpp>
-#include <boost/thread.hpp>
+#include <boost/thread/lock_guard.hpp>
 
 #include <sys/time.h>
 

--- a/cob_people_detection/common/src/face_recognizer.cpp
+++ b/cob_people_detection/common/src/face_recognizer.cpp
@@ -75,8 +75,9 @@
 #include <opencv/highgui.h>
 
 // boost
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/convenience.hpp"
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/convenience.hpp>
+#include <boost/thread.hpp>
 
 #include <sys/time.h>
 


### PR DESCRIPTION
When trying to compile your package on my system, I got some error that boost's lock_guards (and some more stuff from boost having to do with threading) was missing.
Adding this include fixed the issue. 
