### PR TITLE
Replaced '>>' of nested templates with '> >'.

### DIFF
--- a/cob_people_detection/common/include/cob_people_detection/abstract_face_recognizer.h
+++ b/cob_people_detection/common/include/cob_people_detection/abstract_face_recognizer.h
@@ -86,10 +86,10 @@ public:
 	/// @param face_coordinates Bounding boxes of detected faces (input parameter, local coordinates wrt. to respective image patch), outer index corresponds to color_image index
 	/// @param identification_labels Vector of labels of classified faces, both indices correspond with face_coordinates
 	/// @return Return code
-	virtual unsigned long recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<std::vector<cv::Rect>>& face_coordinates,
-			std::vector<std::vector<std::string>>& identification_labels);
-	virtual unsigned long recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<cv::Mat>& depth_images, std::vector<std::vector<cv::Rect>>& face_coordinates,
-			std::vector<std::vector<std::string>>& identification_labels);
+	virtual unsigned long recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<std::vector<cv::Rect> >& face_coordinates,
+			std::vector<std::vector<std::string> >& identification_labels);
+	virtual unsigned long recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<cv::Mat>& depth_images, std::vector<std::vector<cv::Rect> >& face_coordinates,
+			std::vector<std::vector<std::string> >& identification_labels);
 
 	/// Trains a model for the recognition of a given set of faces.
 	/// @param identification_labels_to_train List of labels whose corresponding faces shall be trained.

--- a/cob_people_detection/common/include/cob_people_detection/face_detector.h
+++ b/cob_people_detection/common/include/cob_people_detection/face_detector.h
@@ -103,7 +103,7 @@ public:
 	/// @param face_coordinates Vector of same size as heads_color_images, each entry becomes filled with another vector with the coordinates of detected faces in color image, i.e. outer index corresponds with index of heads_color_images
 	/// @return Return code
 	virtual unsigned long detectColorFaces(std::vector<cv::Mat>& heads_color_images, const std::vector<cv::Mat>& heads_depth_images,
-			std::vector<std::vector<cv::Rect>>& face_coordinates);
+			std::vector<std::vector<cv::Rect> >& face_coordinates);
 
 protected:
 

--- a/cob_people_detection/common/include/cob_people_detection/face_normalizer.h
+++ b/cob_people_detection/common/include/cob_people_detection/face_normalizer.h
@@ -394,11 +394,11 @@ protected:
 
 		if (src.channels() == 3)
 		{
-			cv::Vec<T, 3>* lptr = src.ptr<cv::Vec<T, 3>>(1, 0);
-			cv::Vec<T, 3>* rptr = src.ptr<cv::Vec<T, 3>>(1, 2);
-			cv::Vec<T, 3>* mptr = src.ptr<cv::Vec<T, 3>>(1, 1);
-			cv::Vec<T, 3>* uptr = src.ptr<cv::Vec<T, 3>>(0, 1);
-			cv::Vec<T, 3>* dptr = src.ptr<cv::Vec<T, 3>>(2, 1);
+			cv::Vec<T, 3>* lptr = src.ptr<cv::Vec<T, 3> >(1, 0);
+			cv::Vec<T, 3>* rptr = src.ptr<cv::Vec<T, 3> >(1, 2);
+			cv::Vec<T, 3>* mptr = src.ptr<cv::Vec<T, 3> >(1, 1);
+			cv::Vec<T, 3>* uptr = src.ptr<cv::Vec<T, 3> >(0, 1);
+			cv::Vec<T, 3>* dptr = src.ptr<cv::Vec<T, 3> >(2, 1);
 
 			int normalizer = 4;
 			for (int px = 2 * src.cols + 2; px < (dst.rows * src.cols); ++px)

--- a/cob_people_detection/common/include/munkres/munkres.h
+++ b/cob_people_detection/common/include/munkres/munkres.h
@@ -74,7 +74,7 @@ public:
 	//Load weight array from a vector of vectors of integers
 	//Accepts an object of type vector< vector<int> >, which is
 	//a matrix of any dimensions with integer values > -1
-	void load_weights(std::vector<std::vector<int>> x);
+	void load_weights(std::vector<std::vector<int> > x);
 
 private:
 
@@ -98,10 +98,10 @@ private:
 
 	//The matrix operated on by Munkres' algorithm
 	//(could be better than an array in the future)
-	std::vector<std::vector<cell>> cell_array;
+	std::vector<std::vector<cell> > cell_array;
 
 	//array to store the weights for calculating total weight
-	std::vector<std::vector<int>> weight_array;
+	std::vector<std::vector<int> > weight_array;
 
 	//functions to check if there is a starred zero in the current row or column
 	int find_star_column(int c);

--- a/cob_people_detection/common/src/abstract_face_recognizer.cpp
+++ b/cob_people_detection/common/src/abstract_face_recognizer.cpp
@@ -82,8 +82,8 @@ AbstractFaceRecognizer::~AbstractFaceRecognizer(void)
 {
 }
 
-unsigned long AbstractFaceRecognizer::recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<std::vector<cv::Rect>>& face_coordinates,
-		std::vector<std::vector<std::string>>& identification_labels)
+unsigned long AbstractFaceRecognizer::recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<std::vector<cv::Rect> >& face_coordinates,
+		std::vector<std::vector<std::string> >& identification_labels)
 {
 	// prepare index list
 	identification_labels.clear();
@@ -99,8 +99,8 @@ unsigned long AbstractFaceRecognizer::recognizeFaces(std::vector<cv::Mat>& color
 	}
 	return ipa_Utils::RET_OK;
 }
-unsigned long AbstractFaceRecognizer::recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<cv::Mat>& depth_images, std::vector<std::vector<cv::Rect>>& face_coordinates,
-		std::vector<std::vector<std::string>>& identification_labels)
+unsigned long AbstractFaceRecognizer::recognizeFaces(std::vector<cv::Mat>& color_images, std::vector<cv::Mat>& depth_images, std::vector<std::vector<cv::Rect> >& face_coordinates,
+		std::vector<std::vector<std::string> >& identification_labels)
 {
 	// prepare index list
 	identification_labels.clear();

--- a/cob_people_detection/common/src/face_detector.cpp
+++ b/cob_people_detection/common/src/face_detector.cpp
@@ -112,7 +112,7 @@ FaceDetector::~FaceDetector(void)
 }
 
 unsigned long FaceDetector::detectColorFaces(std::vector<cv::Mat>& heads_color_images, const std::vector<cv::Mat>& heads_depth_images,
-		std::vector<std::vector<cv::Rect>>& face_coordinates)
+		std::vector<std::vector<cv::Rect> >& face_coordinates)
 {
 	if (m_initialized == false)
 	{

--- a/cob_people_detection/common/src/munkres/munkres.cpp
+++ b/cob_people_detection/common/src/munkres/munkres.cpp
@@ -37,7 +37,7 @@ munkres::~munkres(void)
 }
 
 //Load wieght_array from a vector of vectors of integers
-void munkres::load_weights(std::vector<std::vector<int>> x)
+void munkres::load_weights(std::vector<std::vector<int> > x)
 {
 	//get the row and column sizes of the vector passed in
 	int a = x.size(), b = x[0].size();

--- a/cob_people_detection/ros/include/cob_people_detection/detection_tracker_node.h
+++ b/cob_people_detection/ros/include/cob_people_detection/detection_tracker_node.h
@@ -111,7 +111,7 @@ protected:
 	image_transport::ImageTransport* it_;
 	image_transport::SubscriberFilter people_segmentation_image_sub_; ///< Color camera image topic
 
-	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, sensor_msgs::Image>>* sync_input_2_;
+	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, sensor_msgs::Image> >* sync_input_2_;
 	message_filters::Subscriber<cob_people_detection_msgs::DetectionArray> face_position_subscriber_; ///< receives the face messages from the face detector
 	ros::Publisher face_position_publisher_; ///< publisher for the positions of the detected faces
 
@@ -119,7 +119,7 @@ protected:
 
 	std::vector<cob_people_detection_msgs::Detection> face_position_accumulator_; ///< accumulates face positions over time
 	boost::timed_mutex face_position_accumulator_mutex_; ///< secures write and read operations to face_position_accumulator_
-	std::vector<std::map<std::string, double>> face_identification_votes_; ///< collects votes for all names (map index) ever assigned to each detection (vector index) in face_position_accumulator_
+	std::vector<std::map<std::string, double> > face_identification_votes_; ///< collects votes for all names (map index) ever assigned to each detection (vector index) in face_position_accumulator_
 
 	// parameters
 	bool debug_; ///< enables some debug outputs

--- a/cob_people_detection/ros/include/cob_people_detection/face_capture_node.h
+++ b/cob_people_detection/ros/include/cob_people_detection/face_capture_node.h
@@ -144,7 +144,7 @@ protected:
 	//	image_transport::SubscriberFilter people_segmentation_image_sub_; ///< Color camera image topic
 	//	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::Image> >* sync_input_3_;
 	//	message_filters::Subscriber<cob_people_detection_msgs::DetectionArray> face_recognition_subscriber_; ///< receives the face messages from the detection tracker
-	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::Image>>* sync_input_2_;
+	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::Image> >* sync_input_2_;
 	message_filters::Subscriber<cob_people_detection_msgs::ColorDepthImageArray> face_detection_subscriber_; ///< receives the face messages from the face detector
 	image_transport::SubscriberFilter color_image_sub_; ///< Color camera image topic
 

--- a/cob_people_detection/ros/include/cob_people_detection/people_detection_display_node.h
+++ b/cob_people_detection/ros/include/cob_people_detection/people_detection_display_node.h
@@ -110,7 +110,7 @@ protected:
 	image_transport::ImageTransport* it_;
 	image_transport::SubscriberFilter colorimage_sub_; ///< Color camera image topic
 	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, cob_people_detection_msgs::ColorDepthImageArray,
-			sensor_msgs::Image>>* sync_input_3_;
+			sensor_msgs::Image> >* sync_input_3_;
 	//	message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::PointCloud2> >* sync_input_3_;
 	//	message_filters::Subscriber<sensor_msgs::PointCloud2> pointcloud_sub_;
 	message_filters::Subscriber<cob_people_detection_msgs::ColorDepthImageArray> face_detection_subscriber_; ///< receives the face messages from the face detector

--- a/cob_people_detection/ros/src/detection_tracker_node.cpp
+++ b/cob_people_detection/ros/src/detection_tracker_node.cpp
@@ -151,7 +151,7 @@ DetectionTrackerNode::DetectionTrackerNode(ros::NodeHandle nh) :
 	sensor_msgs::Image::ConstPtr nullPtr;
 	if (use_people_segmentation_ == true)
 	{
-		sync_input_2_ = new message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, sensor_msgs::Image>>(2);
+		sync_input_2_ = new message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, sensor_msgs::Image> >(2);
 		sync_input_2_->connectInput(face_position_subscriber_, people_segmentation_image_sub_);
 		sync_input_2_->registerCallback(boost::bind(&DetectionTrackerNode::inputCallback, this, _1, _2));
 	}
@@ -476,8 +476,8 @@ void DetectionTrackerNode::inputCallback(const cob_people_detection_msgs::Detect
 	if (false)
 	{
 		// build distance matrix
-		std::map<int, std::map<int, double>> distance_matrix; // 1. index = face_position_accumulator_ index of previous detections, 2. index = index of current detections, content = spatial distance between the indexed faces
-		std::map<int, std::map<int, double>>::iterator distance_matrix_it;
+		std::map<int, std::map<int, double> > distance_matrix; // 1. index = face_position_accumulator_ index of previous detections, 2. index = index of current detections, content = spatial distance between the indexed faces
+		std::map<int, std::map<int, double> >::iterator distance_matrix_it;
 		for (unsigned int previous_det = 0; previous_det < face_position_accumulator_.size(); previous_det++)
 		{
 			std::map<int, double> distance_row;
@@ -533,7 +533,7 @@ void DetectionTrackerNode::inputCallback(const cob_people_detection_msgs::Detect
 	else
 	{
 		// create the costs matrix (which consist of Eulidean distance in cm and a punishment for dissimilar labels)
-		std::vector < std::vector<int>> costs_matrix(face_position_accumulator_.size(), std::vector<int>(face_detection_indices.size(), 0));
+		std::vector < std::vector<int> > costs_matrix(face_position_accumulator_.size(), std::vector<int>(face_detection_indices.size(), 0));
 		if (debug_)
 			std::cout << "Costs matrix.\n";
 		for (unsigned int previous_det = 0; previous_det < face_position_accumulator_.size(); previous_det++)

--- a/cob_people_detection/ros/src/face_detector_node.cpp
+++ b/cob_people_detection/ros/src/face_detector_node.cpp
@@ -177,7 +177,7 @@ void FaceDetectorNode::head_positions_callback(const cob_people_detection_msgs::
 		}
 		heads_depth_images[i] = cv_cptr->image;
 	}
-	std::vector < std::vector<cv::Rect>> face_coordinates;
+	std::vector < std::vector<cv::Rect> > face_coordinates;
 	face_detector_.detectColorFaces(heads_color_images, heads_depth_images, face_coordinates);
 	// face_normalizer_.normalizeFaces(heads_color_images, heads_depth_images, face_coordinates);
 

--- a/cob_people_detection/ros/src/face_recognizer_node.cpp
+++ b/cob_people_detection/ros/src/face_recognizer_node.cpp
@@ -378,7 +378,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_people_detection_msgs::
 	heads_color_images.resize(face_positions->head_detections.size());
 	std::vector < cv::Mat > heads_depth_images;
 	heads_depth_images.resize(face_positions->head_detections.size());
-	std::vector < std::vector < cv::Rect >> face_bounding_boxes;
+	std::vector < std::vector < cv::Rect > > face_bounding_boxes;
 	face_bounding_boxes.resize(face_positions->head_detections.size());
 	std::vector < cv::Rect > head_bounding_boxes;
 	head_bounding_boxes.resize(face_positions->head_detections.size());
@@ -427,7 +427,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_people_detection_msgs::
 	}
 
 	// --- face recognition ---
-	std::vector < std::vector < std::string >> identification_labels;
+	std::vector < std::vector < std::string > > identification_labels;
 	bool identification_failed = false;
 	if (enable_face_recognition_ == true)
 	{

--- a/cob_people_detection/ros/src/people_detection_display_node.cpp
+++ b/cob_people_detection/ros/src/people_detection_display_node.cpp
@@ -92,7 +92,7 @@ PeopleDetectionDisplayNode::PeopleDetectionDisplayNode(ros::NodeHandle nh) :
 	//	sync_input_3_ = new message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray, cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::PointCloud2> >(30);
 	//	sync_input_3_->connectInput(face_recognition_subscriber_, face_detection_subscriber_, pointcloud_sub_);
 	sync_input_3_ = new message_filters::Synchronizer<message_filters::sync_policies::ApproximateTime<cob_people_detection_msgs::DetectionArray,
-			cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::Image>>(60);
+			cob_people_detection_msgs::ColorDepthImageArray, sensor_msgs::Image> >(60);
 	sync_input_3_->connectInput(face_recognition_subscriber_, face_detection_subscriber_, colorimage_sub_);
 	sync_input_3_->registerCallback(boost::bind(&PeopleDetectionDisplayNode::inputCallback, this, _1, _2, _3));
 


### PR DESCRIPTION
I had trouble compiling the package with nested template expressions where the closing paranthesises weren't separated by a whitespace, so I wrote a patch for that.
(I'm using gcc 4.8.2)
Is there some compiler which doesn't complain about that?
