### PR TITLE
remove global namespaces

### DIFF
--- a/cob_people_detection/ros/launch/coordinator.launch
+++ b/cob_people_detection/ros/launch/coordinator.launch
@@ -5,10 +5,10 @@
 
   <!-- coordinator node for the detection pipeline -->
   <!--rosparam command="load" ns="cob_people_detection/coordinator" file="$(find cob_people_detection)/ros/launch/coordinator_params.yaml"/-->
-  <param if="$(arg using_nodelets)" name="cob_people_detection/coordinator/namespace_gateway" type="str" value="/cam3d_nodelet_manager"/>
-  <param unless="$(arg using_nodelets)" name="cob_people_detection/coordinator/namespace_gateway" type="str" value="/cob_people_detection/sensor_message_gateway/sensor_message_gateway"/>
-  <node name="coordinator" pkg="cob_people_detection" ns="cob_people_detection/coordinator" type="coordinator_node" output="screen">
-    <remap from="detection_array" to="/cob_people_detection/detection_tracker/face_position_array"/>
+  <node name="coordinator" pkg="cob_people_detection" type="coordinator_node" output="screen">
+    <param if="$(arg using_nodelets)" name="namespace_gateway" type="str" value="/cam3d_nodelet_manager"/>
+    <param unless="$(arg using_nodelets)" name="namespace_gateway" type="str" value="sensor_message_gateway/sensor_message_gateway"/>
+    <remap from="~detection_array" to="detection_tracker/face_position_array"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/coordinator.launch
+++ b/cob_people_detection/ros/launch/coordinator.launch
@@ -4,10 +4,10 @@
   <arg name="using_nodelets" default="false"/>
 
   <!-- coordinator node for the detection pipeline -->
-  <!--rosparam command="load" ns="/cob_people_detection/coordinator" file="$(find cob_people_detection)/ros/launch/coordinator_params.yaml"/-->
+  <!--rosparam command="load" ns="cob_people_detection/coordinator" file="$(find cob_people_detection)/ros/launch/coordinator_params.yaml"/-->
   <param if="$(arg using_nodelets)" name="cob_people_detection/coordinator/namespace_gateway" type="str" value="/cam3d_nodelet_manager"/>
   <param unless="$(arg using_nodelets)" name="cob_people_detection/coordinator/namespace_gateway" type="str" value="/cob_people_detection/sensor_message_gateway/sensor_message_gateway"/>
-  <node name="coordinator" pkg="cob_people_detection" ns="/cob_people_detection/coordinator" type="coordinator_node" output="screen">
+  <node name="coordinator" pkg="cob_people_detection" ns="cob_people_detection/coordinator" type="coordinator_node" output="screen">
     <remap from="detection_array" to="/cob_people_detection/detection_tracker/face_position_array"/>
   </node>
 

--- a/cob_people_detection/ros/launch/detection_tracker.launch
+++ b/cob_people_detection/ros/launch/detection_tracker.launch
@@ -9,5 +9,6 @@
     <rosparam command="load" file="$(find cob_people_detection)/ros/launch/detection_tracker_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
     <remap from="~face_position_array_in" to="face_recognizer/face_recognitions"/>
+    <!--remap from="people_segmentation_image" to="/cob_people_detection/people_segmentation/people_segmentation_image"/-->
   </node>
 </launch>

--- a/cob_people_detection/ros/launch/detection_tracker.launch
+++ b/cob_people_detection/ros/launch/detection_tracker.launch
@@ -5,11 +5,9 @@
   <!-- <node pkg="cob_people_detection" ns="cob_people_detection/people_segmentation" type="openni_tracker" name="openniTrackerNode" output="screen"/> -->
 
   <!-- detection tracker node (tracks faces in color and depth image and publishes their positions) -->
-  <rosparam command="load" ns="cob_people_detection/detection_tracker" file="$(find cob_people_detection)/ros/launch/detection_tracker_params.yaml"/>
-  <node name="detection_tracker" pkg="cob_people_detection" ns="cob_people_detection/detection_tracker" type="detection_tracker_node" output="screen">
-    <remap from="face_position_array_in" to="/cob_people_detection/face_recognizer/face_recognitions"/>
-    <remap from="people_segmentation_image" to="/cob_people_detection/people_segmentation/people_segmentation_image"/>
-
+  <node name="detection_tracker" pkg="cob_people_detection" type="detection_tracker_node" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/detection_tracker_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
+    <remap from="~face_position_array_in" to="face_recognizer/face_recognitions"/>
   </node>
 </launch>

--- a/cob_people_detection/ros/launch/detection_tracker.launch
+++ b/cob_people_detection/ros/launch/detection_tracker.launch
@@ -5,12 +5,11 @@
   <!-- <node pkg="cob_people_detection" ns="cob_people_detection/people_segmentation" type="openni_tracker" name="openniTrackerNode" output="screen"/> -->
 
   <!-- detection tracker node (tracks faces in color and depth image and publishes their positions) -->
-  <rosparam command="load" ns="/cob_people_detection/detection_tracker" file="$(find cob_people_detection)/ros/launch/detection_tracker_params.yaml"/>
-  <node name="detection_tracker" pkg="cob_people_detection" ns="/cob_people_detection/detection_tracker" type="detection_tracker_node" output="screen">
+  <rosparam command="load" ns="cob_people_detection/detection_tracker" file="$(find cob_people_detection)/ros/launch/detection_tracker_params.yaml"/>
+  <node name="detection_tracker" pkg="cob_people_detection" ns="cob_people_detection/detection_tracker" type="detection_tracker_node" output="screen">
     <remap from="face_position_array_in" to="/cob_people_detection/face_recognizer/face_recognitions"/>
     <remap from="people_segmentation_image" to="/cob_people_detection/people_segmentation/people_segmentation_image"/>
 
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
   </node>
-
 </launch>

--- a/cob_people_detection/ros/launch/face_capture.launch
+++ b/cob_people_detection/ros/launch/face_capture.launch
@@ -2,13 +2,10 @@
 
 <launch>
   <!-- face capture node (captures faces and stores them in the database) -->
-  <rosparam command="load" ns="cob_people_detection/face_capture" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
-  <node name="face_capture" pkg="cob_people_detection" ns="cob_people_detection/face_capture" type="face_capture_node" output="screen"><!-- launch-prefix="gdb -ex run args"--><!--launch-prefix="valgrind"-->
-    <remap from="face_detections" to="/cob_people_detection/face_detector/face_positions"/>
-    <!--remap from="color_image" to="/cob_people_detection/image_flip/colorimage_out"/--> <!-- only activate on cob3 robots -->
-    <remap from="color_image" to="/cob_people_detection/sensor_message_gateway/colorimage_out"/>
-	
+  <node name="face_capture" pkg="cob_people_detection" type="face_capture_node" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
+    <remap from="~face_detections" to="face_detector/face_positions"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/face_capture.launch
+++ b/cob_people_detection/ros/launch/face_capture.launch
@@ -6,6 +6,7 @@
     <rosparam command="load" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
     <remap from="~face_detections" to="face_detector/face_positions"/>
+    <remap from="~color_image" to="sensor_message_gateway/colorimage_out"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/face_capture.launch
+++ b/cob_people_detection/ros/launch/face_capture.launch
@@ -2,8 +2,8 @@
 
 <launch>
   <!-- face capture node (captures faces and stores them in the database) -->
-  <rosparam command="load" ns="/cob_people_detection/face_capture" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
-  <node name="face_capture" pkg="cob_people_detection" ns="/cob_people_detection/face_capture" type="face_capture_node" output="screen"><!-- launch-prefix="gdb -ex run args"--><!--launch-prefix="valgrind"-->
+  <rosparam command="load" ns="cob_people_detection/face_capture" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
+  <node name="face_capture" pkg="cob_people_detection" ns="cob_people_detection/face_capture" type="face_capture_node" output="screen"><!-- launch-prefix="gdb -ex run args"--><!--launch-prefix="valgrind"-->
     <remap from="face_detections" to="/cob_people_detection/face_detector/face_positions"/>
     <!--remap from="color_image" to="/cob_people_detection/image_flip/colorimage_out"/--> <!-- only activate on cob3 robots -->
     <remap from="color_image" to="/cob_people_detection/sensor_message_gateway/colorimage_out"/>

--- a/cob_people_detection/ros/launch/face_detector.launch
+++ b/cob_people_detection/ros/launch/face_detector.launch
@@ -2,8 +2,8 @@
 
 <launch>
   <!-- face detection node (detects faces in color image and publishes their positions) -->
-  <rosparam command="load" ns="/cob_people_detection/face_detector" file="$(find cob_people_detection)/ros/launch/face_detector_params.yaml"/>
-  <node name="face_detector" pkg="cob_people_detection" ns="/cob_people_detection/face_detector" type="face_detector_node" output="screen">
+  <rosparam command="load" ns="cob_people_detection/face_detector" file="$(find cob_people_detection)/ros/launch/face_detector_params.yaml"/>
+  <node name="face_detector" pkg="cob_people_detection" ns="cob_people_detection/face_detector" type="face_detector_node" output="screen">
     <remap from="head_positions" to="/cob_people_detection/head_detector/head_positions"/>
 	
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>

--- a/cob_people_detection/ros/launch/face_detector.launch
+++ b/cob_people_detection/ros/launch/face_detector.launch
@@ -2,11 +2,9 @@
 
 <launch>
   <!-- face detection node (detects faces in color image and publishes their positions) -->
-  <rosparam command="load" ns="cob_people_detection/face_detector" file="$(find cob_people_detection)/ros/launch/face_detector_params.yaml"/>
-  <node name="face_detector" pkg="cob_people_detection" ns="cob_people_detection/face_detector" type="face_detector_node" output="screen">
-    <remap from="head_positions" to="/cob_people_detection/head_detector/head_positions"/>
-	
+  <node name="face_detector" pkg="cob_people_detection" type="face_detector_node" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/face_detector_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
+    <remap from="~head_positions" to="head_detector/head_positions"/>
   </node>
-
 </launch>

--- a/cob_people_detection/ros/launch/face_recognizer.launch
+++ b/cob_people_detection/ros/launch/face_recognizer.launch
@@ -2,8 +2,8 @@
 
 <launch>
   <!-- face recognition node (recognizes faces in color image and publishes their positions) -->
-  <rosparam command="load" ns="/cob_people_detection/face_recognizer" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
-  <node name="face_recognizer" pkg="cob_people_detection" ns="/cob_people_detection/face_recognizer" type="face_recognizer_node" output="screen"> <!--launch-prefix= "gdb -ex run args"-->
+  <rosparam command="load" ns="cob_people_detection/face_recognizer" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
+  <node name="face_recognizer" pkg="cob_people_detection" ns="cob_people_detection/face_recognizer" type="face_recognizer_node" output="screen"> <!--launch-prefix= "gdb -ex run args"-->
     <remap from="face_positions" to="/cob_people_detection/face_detector/face_positions"/>
     <!--remap from="face_positions" to="/cob_people_detection/face_normalizer/norm_faces"/-->
   </node>

--- a/cob_people_detection/ros/launch/face_recognizer.launch
+++ b/cob_people_detection/ros/launch/face_recognizer.launch
@@ -2,10 +2,9 @@
 
 <launch>
   <!-- face recognition node (recognizes faces in color image and publishes their positions) -->
-  <rosparam command="load" ns="cob_people_detection/face_recognizer" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
-  <node name="face_recognizer" pkg="cob_people_detection" ns="cob_people_detection/face_recognizer" type="face_recognizer_node" output="screen"> <!--launch-prefix= "gdb -ex run args"-->
-    <remap from="face_positions" to="/cob_people_detection/face_detector/face_positions"/>
-    <!--remap from="face_positions" to="/cob_people_detection/face_normalizer/norm_faces"/-->
+  <node name="face_recognizer" pkg="cob_people_detection" type="face_recognizer_node" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/face_recognizer_params.yaml"/>
+    <remap from="~face_positions" to="face_detector/face_positions"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/head_detector.launch
+++ b/cob_people_detection/ros/launch/head_detector.launch
@@ -1,15 +1,13 @@
 <?xml version="1.0"?>
 
 <launch>
+
+  <arg name="pointcloud_rgb_in_topic"/>
+
   <!-- head detection node (detects faces in depth image and publishes their positions) -->
-  <rosparam command="load" ns="cob_people_detection/head_detector" file="$(find cob_people_detection)/ros/launch/head_detector_params.yaml"/>
-  <node name="head_detector" pkg="cob_people_detection" ns="cob_people_detection/head_detector" type="head_detector_node" output="screen">
-    <!--remap from="pointcloud_rgb" to="/cam3d/depth/upright/points"/-->
-    <!--remap from="pointcloud_rgb" to="/cob_people_detection/image_flip/pointcloud_rgb_out"/-->  <!-- only activate on cob3 robots -->
-
-    <remap from="pointcloud_rgb" to="cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
-	
+  <node name="head_detector" pkg="cob_people_detection" type="head_detector_node" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/head_detector_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
+    <remap from="~pointcloud_rgb" to="$(arg pointcloud_rgb_in_topic)"/>
   </node>
-
 </launch>

--- a/cob_people_detection/ros/launch/head_detector.launch
+++ b/cob_people_detection/ros/launch/head_detector.launch
@@ -2,12 +2,10 @@
 
 <launch>
 
-  <arg name="pointcloud_rgb_in_topic"/>
-
   <!-- head detection node (detects faces in depth image and publishes their positions) -->
   <node name="head_detector" pkg="cob_people_detection" type="head_detector_node" output="screen">
     <rosparam command="load" file="$(find cob_people_detection)/ros/launch/head_detector_params.yaml"/>
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
-    <remap from="~pointcloud_rgb" to="$(arg pointcloud_rgb_in_topic)"/>
+    <remap from="~pointcloud_rgb" to="sensor_message_gateway/pointcloud_rgb_out"/>
   </node>
 </launch>

--- a/cob_people_detection/ros/launch/head_detector.launch
+++ b/cob_people_detection/ros/launch/head_detector.launch
@@ -2,12 +2,12 @@
 
 <launch>
   <!-- head detection node (detects faces in depth image and publishes their positions) -->
-  <rosparam command="load" ns="/cob_people_detection/head_detector" file="$(find cob_people_detection)/ros/launch/head_detector_params.yaml"/>
-  <node name="head_detector" pkg="cob_people_detection" ns="/cob_people_detection/head_detector" type="head_detector_node" output="screen">
+  <rosparam command="load" ns="cob_people_detection/head_detector" file="$(find cob_people_detection)/ros/launch/head_detector_params.yaml"/>
+  <node name="head_detector" pkg="cob_people_detection" ns="cob_people_detection/head_detector" type="head_detector_node" output="screen">
     <!--remap from="pointcloud_rgb" to="/cam3d/depth/upright/points"/-->
     <!--remap from="pointcloud_rgb" to="/cob_people_detection/image_flip/pointcloud_rgb_out"/-->  <!-- only activate on cob3 robots -->
 
-    <remap from="pointcloud_rgb" to="/cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
+    <remap from="pointcloud_rgb" to="cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
 	
     <param name="data_directory" type="string" value="$(find cob_people_detection)/common/files/"/>
   </node>

--- a/cob_people_detection/ros/launch/people_detection.launch
+++ b/cob_people_detection/ros/launch/people_detection.launch
@@ -6,7 +6,7 @@
   <arg name="colorimage_in_topic" default="/$(arg camera_namespace)/rgb/image_raw"/>    <!-- very different between openni driver versions, might also be /$(arg camera_namespace)/rgb/image_color -->
   <arg name="pointcloud_rgb_in_topic" default="/$(arg camera_namespace)/depth_registered/points"/>    <!-- very different between openni driver versions, might also be /$(arg camera_namespace)/rgb/points or /$(arg camera_namespace)/depth/points_xyzrgb or /$(arg camera_namespace)/depth_registered/points -->
 
-  <arg name="using_nodelets" default="false"/>    <!-- for using people detection with the faster nodelet mode, provide argument true -->"/>
+  <arg name="using_nodelets" default="false"/>    <!-- for using people detection with the faster nodelet mode, provide argument true -->
   <arg name="nodelet_manager" default="/$(arg camera_namespace)/$(arg camera_namespace)_nodelet_manager"/>    <!-- name of the nodelet manager started by the openni driver, default for the openni driver is camera_nodelet_manager, 
 for Care-O-bot default is cam3d_nodelet_manager -->
   <arg name="start_manager" default="false"/>     <!-- if you do not like to use the nodelet manager provided by the openni driver, specify your own by setting this parameter to true and providing the name of your manager with argument nodelet_manager-->

--- a/cob_people_detection/ros/launch/people_detection.launch
+++ b/cob_people_detection/ros/launch/people_detection.launch
@@ -6,12 +6,11 @@
   <arg name="colorimage_in_topic" default="/$(arg camera_namespace)/rgb/image_raw"/>    <!-- very different between openni driver versions, might also be /$(arg camera_namespace)/rgb/image_color -->
   <arg name="pointcloud_rgb_in_topic" default="/$(arg camera_namespace)/depth_registered/points"/>    <!-- very different between openni driver versions, might also be /$(arg camera_namespace)/rgb/points or /$(arg camera_namespace)/depth/points_xyzrgb or /$(arg camera_namespace)/depth_registered/points -->
 
-  <arg name="using_nodelets" default="false"/>    <!-- for using people detection with the faster nodelet mode, provide argument true -->
-  <arg name="nodelet_manager" default="$(arg camera_namespace)/$(arg camera_namespace)_nodelet_manager"/>    <!-- name of the nodelet manager started by the openni driver, default for the openni driver is camera_nodelet_manager, 
+  <arg name="using_nodelets" default="false"/>    <!-- for using people detection with the faster nodelet mode, provide argument true -->"/>
+  <arg name="nodelet_manager" default="/$(arg camera_namespace)/$(arg camera_namespace)_nodelet_manager"/>    <!-- name of the nodelet manager started by the openni driver, default for the openni driver is camera_nodelet_manager, 
 for Care-O-bot default is cam3d_nodelet_manager -->
   <arg name="start_manager" default="false"/>     <!-- if you do not like to use the nodelet manager provided by the openni driver, specify your own by setting this parameter to true and providing the name of your manager with argument nodelet_manager-->
   <arg name="display_results_with_image_view" default="true"/>		<!-- set to false if you do not like to display the camera image with names attached to detected faces within an image_view window --> 
-
 
   <!-- nodelet or non-nodelet specific launch files -->
   <group unless="$(arg using_nodelets)">
@@ -20,28 +19,23 @@ for Care-O-bot default is cam3d_nodelet_manager -->
       <arg name="colorimage_in_topic" value="$(arg colorimage_in_topic)"/>
       <arg name="pointcloud_rgb_in_topic" value="$(arg pointcloud_rgb_in_topic)"/>
     </include>
-    <!--include file="$(find cob_people_detection)/ros/launch/image_flip.launch"/--> <!-- only activate on cob3 robots -->
   </group>
   <group if="$(arg using_nodelets)">
     <!-- special launch files for usage with nodelets -->
     <node if="$(arg start_manager)" pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)"  args="manager" output="screen"/>
     <include file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_nodelet.launch">
+      <arg name="nodelet_namespace" value="$(arg camera_namespace)"/>
       <arg name="nodelet_manager" value="$(arg nodelet_manager)"/>
       <arg name="colorimage_in_topic" value="$(arg colorimage_in_topic)"/>
       <arg name="pointcloud_rgb_in_topic" value="$(arg pointcloud_rgb_in_topic)"/>
     </include>
-    <!-- include file="$(find cob_people_detection)/ros/launch/image_flip_nodelet.launch">
-    	<arg name="nodelet_manager" value="$(arg nodelet_manager)"/>
-    </include--> <!-- only activate on cob3 robots -->
   </group>
 
   <!-- remaining launch files -->
   <param name="data_storage_directory" type="string" value="$(env HOME)/.ros/cob_people_detection/files/"/>
-  <!--param name="/cob_people_detection/data_directoryTEST" type="string" value="$(find cob_people_detection)/common/files/"/-->
 
   <include file="$(find cob_people_detection)/ros/launch/head_detector.launch"/>
   <include file="$(find cob_people_detection)/ros/launch/face_detector.launch"/>
-  <!--include file="$(find cob_people_detection)/ros/launch/face_normalizer.launch"/-->
   <include file="$(find cob_people_detection)/ros/launch/face_recognizer.launch"/>
   <include file="$(find cob_people_detection)/ros/launch/detection_tracker.launch"/>
   <include file="$(find cob_people_detection)/ros/launch/people_detection_display.launch">
@@ -51,10 +45,4 @@ for Care-O-bot default is cam3d_nodelet_manager -->
   <include file="$(find cob_people_detection)/ros/launch/coordinator.launch">
     <arg name="using_nodelets" value="$(arg using_nodelets)"/>
   </include>
-
-
-
-
-  <!-- Openni people segmentation and tracker (not tested for compatibility for a long time!) - adapted to publish the segmented image (does not work upside down, i.e. when robot is watching backwards) (comment out if you do not use the openni-tracker) -->
-  <!-- <node pkg="cob_people_detection" ns="cob_people_detection/openni_tracker" type="openni_tracker" name="openniTrackerNode" output="screen"/> -->
 </launch>

--- a/cob_people_detection/ros/launch/people_detection.launch
+++ b/cob_people_detection/ros/launch/people_detection.launch
@@ -36,7 +36,7 @@ for Care-O-bot default is cam3d_nodelet_manager -->
   </group>
 
   <!-- remaining launch files -->
-  <param name="/cob_people_detection/data_storage_directory" type="string" value="$(env HOME)/.ros/cob_people_detection/files/"/>
+  <param name="data_storage_directory" type="string" value="$(env HOME)/.ros/cob_people_detection/files/"/>
   <!--param name="/cob_people_detection/data_directoryTEST" type="string" value="$(find cob_people_detection)/common/files/"/-->
 
   <include file="$(find cob_people_detection)/ros/launch/head_detector.launch"/>

--- a/cob_people_detection/ros/launch/people_detection_display.launch
+++ b/cob_people_detection/ros/launch/people_detection_display.launch
@@ -4,18 +4,16 @@
   <arg name="display_results_with_image_view" default="true"/>   <!-- set to false if you do not like to display the camera image with names attached to detected faces within an image_view window -->
 
   <!-- display node for the detections -->
-  <rosparam command="load" ns="cob_people_detection/people_detection_display" file="$(find cob_people_detection)/ros/launch/people_detection_display_params.yaml"/>
-  <node pkg="cob_people_detection" ns="cob_people_detection/people_detection_display" type="people_detection_display_node" name="people_detection_display" output="screen">
-    <remap from="face_position_array" to="/cob_people_detection/detection_tracker/face_position_array"/>
-    <remap from="face_detections" to="/cob_people_detection/face_detector/face_positions"/>
-    <!--remap from="pointcloud_in" to="/cob_people_detection/image_flip/pointcloud_rgb_out"/-->
-    <!--remap from="colorimage_in" to="/cob_people_detection/image_flip/colorimage_out"/--> <!-- only activate on cob3 robots -->
-    <remap from="colorimage_in" to="/cob_people_detection/sensor_message_gateway/colorimage_out"/>
+  <node pkg="cob_people_detection" type="people_detection_display_node" name="people_detection_display" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/people_detection_display_params.yaml"/>
+    <remap from="~face_position_array" to="detection_tracker/face_position_array"/>
+    <remap from="~face_detections" to="face_detector/face_positions"/>
+    <remap from="~colorimage_in" to="sensor_message_gateway/colorimage_out"/>
   </node>
 
   <!-- Image viewer display -->
   <node if="$(arg display_results_with_image_view)" name="people_detection_viewer" pkg="image_view" type="image_view" respawn="false" output="screen">
-    <remap from="image" to="/cob_people_detection/people_detection_display/face_position_image"/>
+    <remap from="image" to="people_detection_display/face_position_image"/>
     <param name="autosize" value="true"/>
   </node>
 

--- a/cob_people_detection/ros/launch/sensor_message_gateway.launch
+++ b/cob_people_detection/ros/launch/sensor_message_gateway.launch
@@ -5,16 +5,16 @@
   <arg name="pointcloud_rgb_in_topic" default="/cam3d/rgb/points"/>
 
   <!-- sensor message gateway node (forwards sensor messages in a desired rate) -->
-  <rosparam command="load" ns="/cob_people_detection/sensor_message_gateway" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
-  <node name="sensor_message_gateway" pkg="cob_people_detection" ns="/cob_people_detection/sensor_message_gateway" type="sensor_message_gateway_node" output="screen"> <!--launch-prefix="valgrind"-->
+  <rosparam command="load" ns="cob_people_detection/sensor_message_gateway" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
+  <node name="sensor_message_gateway" pkg="cob_people_detection" ns="cob_people_detection/sensor_message_gateway" type="sensor_message_gateway_node" output="screen"> <!--launch-prefix="valgrind"-->
     <!--remap from="pointcloud_rgb_in" to="/camera/depth_registered/points"/-->
     <!--remap from="pointcloud_rgb_in" to="/cam3d/depth/points_xyzrgb"/-->
     <remap from="pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
-    <remap from="pointcloud_rgb_out" to="/cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
+    <remap from="pointcloud_rgb_out" to="cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
     <!--remap from="colorimage_in" to="/camera/rgb/image_color"/-->
     <!--remap from="colorimage_in" to="/cam3d/rgb/image"/-->
     <remap from="colorimage_in" to="$(arg colorimage_in_topic)"/>
-    <remap from="colorimage_out" to="/cob_people_detection/sensor_message_gateway/colorimage_out"/>
+    <remap from="colorimage_out" to="cob_people_detection/sensor_message_gateway/colorimage_out"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/sensor_message_gateway.launch
+++ b/cob_people_detection/ros/launch/sensor_message_gateway.launch
@@ -5,7 +5,7 @@
   <arg name="pointcloud_rgb_in_topic"/>
 
   <!-- sensor message gateway node (forwards sensor messages in a desired rate) -->
-  <node name="sensor_message_gateway" pkg="cob_people_detection" type="sensor_message_gateway_node" output="screen"> <!--launch-prefix="valgrind"-->
+  <node name="sensor_message_gateway" pkg="cob_people_detection" type="sensor_message_gateway_node" output="screen">
     <rosparam command="load" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
     <remap from="~pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
     <remap from="~colorimage_in" to="$(arg colorimage_in_topic)"/>

--- a/cob_people_detection/ros/launch/sensor_message_gateway.launch
+++ b/cob_people_detection/ros/launch/sensor_message_gateway.launch
@@ -1,20 +1,14 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="colorimage_in_topic" default="/cam3d/rgb/image_color"/>
-  <arg name="pointcloud_rgb_in_topic" default="/cam3d/rgb/points"/>
+  <arg name="colorimage_in_topic"/>
+  <arg name="pointcloud_rgb_in_topic"/>
 
   <!-- sensor message gateway node (forwards sensor messages in a desired rate) -->
-  <rosparam command="load" ns="cob_people_detection/sensor_message_gateway" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
-  <node name="sensor_message_gateway" pkg="cob_people_detection" ns="cob_people_detection/sensor_message_gateway" type="sensor_message_gateway_node" output="screen"> <!--launch-prefix="valgrind"-->
-    <!--remap from="pointcloud_rgb_in" to="/camera/depth_registered/points"/-->
-    <!--remap from="pointcloud_rgb_in" to="/cam3d/depth/points_xyzrgb"/-->
-    <remap from="pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
-    <remap from="pointcloud_rgb_out" to="cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
-    <!--remap from="colorimage_in" to="/camera/rgb/image_color"/-->
-    <!--remap from="colorimage_in" to="/cam3d/rgb/image"/-->
-    <remap from="colorimage_in" to="$(arg colorimage_in_topic)"/>
-    <remap from="colorimage_out" to="cob_people_detection/sensor_message_gateway/colorimage_out"/>
+  <node name="sensor_message_gateway" pkg="cob_people_detection" type="sensor_message_gateway_node" output="screen"> <!--launch-prefix="valgrind"-->
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
+    <remap from="~pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
+    <remap from="~colorimage_in" to="$(arg colorimage_in_topic)"/>
   </node>
 
 </launch>

--- a/cob_people_detection/ros/launch/sensor_message_gateway_nodelet.launch
+++ b/cob_people_detection/ros/launch/sensor_message_gateway_nodelet.launch
@@ -1,22 +1,18 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="nodelet_manager" default="cam3d_nodelet_manager"/>
-  <arg name="colorimage_in_topic" default="/cam3d/rgb/image_color"/>
-  <arg name="pointcloud_rgb_in_topic" default="/cam3d/rgb/points"/>
+  <arg name="nodelet_namespace"/>
+  <arg name="nodelet_manager"/>
+  <arg name="colorimage_in_topic"/>
+  <arg name="pointcloud_rgb_in_topic"/>
 
   <!-- sensor message gateway node (forwards sensor messages in a desired rate) -->
-  <rosparam command="load" ns="/cob_people_detection/sensor_message_gateway" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
-  <node pkg="nodelet" type="nodelet" name="SensorMessageGatewayNodelet" ns="/cob_people_detection/sensor_message_gateway" args="load cob_people_detection/SensorMessageGatewayNodelet /$(arg nodelet_manager)" output="screen">
-    <!--remap from="pointcloud_rgb_in" to="/cam3d/depth_registered/points"/-->
-    <!--remap from="pointcloud_rgb_in" to="/cam3d/depth/points_xyzrgb"/-->
-    <!--remap from="pointcloud_rgb_in" to="/cam3d/rgb/points"/-->
-    <remap from="pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
-    <remap from="pointcloud_rgb_out" to="/cob_people_detection/sensor_message_gateway/pointcloud_rgb_out"/>
-    <!--remap from="colorimage_in" to="/cam3d/rgb/image"/-->
-    <!--remap from="colorimage_in" to="/cam3d/rgb/image_color"/-->
-    <remap from="colorimage_in" to="$(arg colorimage_in_topic)"/>
-    <remap from="colorimage_out" to="/cob_people_detection/sensor_message_gateway/colorimage_out"/>
+  <node pkg="nodelet" type="nodelet" name="SensorMessageGatewayNodelet" args="load cob_people_detection/SensorMessageGatewayNodelet $(arg nodelet_manager)" output="screen">
+    <rosparam command="load" file="$(find cob_people_detection)/ros/launch/sensor_message_gateway_params.yaml"/>
+    <remap from="$(arg nodelet_namespace)/pointcloud_rgb_in" to="$(arg pointcloud_rgb_in_topic)"/>
+    <remap from="$(arg nodelet_namespace)/colorimage_in" to="$(arg colorimage_in_topic)"/>
+    <remap from="$(arg nodelet_namespace)/pointcloud_rgb_out" to="sensor_message_gateway/pointcloud_rgb_out"/>
+    <remap from="$(arg nodelet_namespace)/colorimage_out" to="sensor_message_gateway/colorimage_out"/>
   </node>                 
 
 </launch>

--- a/cob_people_detection/ros/src/coordinator_node.cpp
+++ b/cob_people_detection/ros/src/coordinator_node.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "coordinator_node");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceRecognizerNode class instance
 	CoordinatorNode coordinator_node(nh);

--- a/cob_people_detection/ros/src/detection_tracker_node.cpp
+++ b/cob_people_detection/ros/src/detection_tracker_node.cpp
@@ -681,7 +681,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "detection_tracker");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceRecognizerNode class instance
 	DetectionTrackerNode detection_tracker_node(nh);

--- a/cob_people_detection/ros/src/face_capture_node.cpp
+++ b/cob_people_detection/ros/src/face_capture_node.cpp
@@ -85,7 +85,7 @@ FaceCaptureNode::FaceCaptureNode(ros::NodeHandle nh)
 	int  norm_size;						// Desired width and height of the Eigenfaces (=eigenvectors).
 
 	std::cout << "\n---------------------------\nFace Capture Node Parameters:\n---------------------------\n";
-	if(!node_handle_.getParam("/cob_people_detection/data_storage_directory", data_directory_)) std::cout<<"PARAM NOT AVAILABLE"<<std::endl;
+	if(!node_handle_.getParam("data_storage_directory", data_directory_)) std::cout<<"PARAM NOT AVAILABLE"<<std::endl;
 	std::cout << "data_directory = " << data_directory_ << "\n";
 	node_handle_.param("norm_size", norm_size, 100);
 	std::cout << "norm_size = " << norm_size << "\n";
@@ -396,7 +396,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "face_capture");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceRecognizerNode class instance
 	FaceCaptureNode face_capture_node(nh);

--- a/cob_people_detection/ros/src/face_detector_node.cpp
+++ b/cob_people_detection/ros/src/face_detector_node.cpp
@@ -219,7 +219,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "face_detector");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceDetectorNode class instance
 	FaceDetectorNode face_detector_node(nh);

--- a/cob_people_detection/ros/src/face_recognizer_node.cpp
+++ b/cob_people_detection/ros/src/face_recognizer_node.cpp
@@ -98,7 +98,7 @@ FaceRecognizerNode::FaceRecognizerNode(ros::NodeHandle nh) :
 	std::vector < std::string > identification_labels_to_recognize; // a list of labels of persons that shall be recognized
 	std::cout << "\n--------------------------\nFace Recognizer Parameters:\n--------------------------\n";
 	//if(!node_handle_.getParam("~data_directory", data_directory_)) std::cout<<"PARAM NOT AVAILABLE"<<std::endl;
-	if (!node_handle_.getParam("/cob_people_detection/data_storage_directory", data_directory_))
+	if (!node_handle_.getParam("data_storage_directory", data_directory_))
 		std::cout << "PARAM NOT AVAILABLE" << std::endl;
 	std::cout << "data_directory = " << data_directory_ << "\n";
 	node_handle_.param("enable_face_recognition", enable_face_recognition_, true);
@@ -590,7 +590,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "face_recognizer");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceRecognizerNode class instance
 	FaceRecognizerNode face_recognizer_node(nh);

--- a/cob_people_detection/ros/src/head_detector_node.cpp
+++ b/cob_people_detection/ros/src/head_detector_node.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "head_detector");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create HeadDetectorNode class instance
 	HeadDetectorNode head_detector_node(nh);

--- a/cob_people_detection/ros/src/people_detection_display_node.cpp
+++ b/cob_people_detection/ros/src/people_detection_display_node.cpp
@@ -217,7 +217,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "people_detection_display");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create FaceRecognizerNode class instance
 	PeopleDetectionDisplayNode people_detection_display_node(nh);

--- a/cob_people_detection/ros/src/sensor_message_gateway_main.cpp
+++ b/cob_people_detection/ros/src/sensor_message_gateway_main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
 	ros::init(argc, argv, "sensor_message_gateway");
 
 	// Create a handle for this node, initialize node
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 
 	// Create SensorMessageGatewayNode class instance
 	cob_people_detection::SensorMessageGatewayNode sensor_message_gateway_node(nh);


### PR DESCRIPTION
this allows the people detection to be started multiple times, e.g. once for each camera in a left and right camera setup.

@ipa-rmb: please review
