### PR TITLE
fix output messages

### DIFF
--- a/cob_people_detection/ros/include/cob_people_detection/detection_tracker_node.h
+++ b/cob_people_detection/ros/include/cob_people_detection/detection_tracker_node.h
@@ -167,7 +167,7 @@ public:
 	/// @return Return code.
 	unsigned long removeMultipleInstancesOfLabel();
 
-	unsigned long prepareFacePositionMessage(cob_perception_msgs::DetectionArray& face_position_msg_out, ros::Time image_recording_time);
+	unsigned long prepareFacePositionMessage(cob_perception_msgs::DetectionArray& face_position_msg_out, ros::Time image_recording_time, std::string frame_id);
 
 	/// checks the detected faces from the input topic against the people segmentation and outputs faces if both are positive
 	void inputCallback(const cob_perception_msgs::DetectionArray::ConstPtr& face_position_msg_in, const sensor_msgs::Image::ConstPtr& people_segmentation_image_msg);

--- a/cob_people_detection/ros/src/detection_tracker_node.cpp
+++ b/cob_people_detection/ros/src/detection_tracker_node.cpp
@@ -262,7 +262,7 @@ unsigned long DetectionTrackerNode::copyDetection(const cob_perception_msgs::Det
 	// else dest.detector = src.detector;
 	dest.detector = src.detector;
 
-	dest.header = src.header; //ros::Time::now();
+	dest.header = src.header;
 
 	return ipa_Utils::RET_OK;
 }
@@ -350,7 +350,7 @@ unsigned long DetectionTrackerNode::removeMultipleInstancesOfLabel()
 	return ipa_Utils::RET_OK;
 }
 
-unsigned long DetectionTrackerNode::prepareFacePositionMessage(cob_perception_msgs::DetectionArray& face_position_msg_out, ros::Time image_recording_time)
+unsigned long DetectionTrackerNode::prepareFacePositionMessage(cob_perception_msgs::DetectionArray& face_position_msg_out, ros::Time image_recording_time, std::string frame_id)
 {
 	// publish face positions
 	std::vector < cob_perception_msgs::Detection > faces_to_publish;
@@ -378,7 +378,7 @@ unsigned long DetectionTrackerNode::prepareFacePositionMessage(cob_perception_ms
 	//      		  face_position_msg_out.detections[i].label = "0000";
 	//        }
 	face_position_msg_out.header.stamp = image_recording_time;
-
+	face_position_msg_out.header.frame_id = frame_id;
 	return ipa_Utils::RET_OK;
 }
 
@@ -626,8 +626,8 @@ void DetectionTrackerNode::inputCallback(const cob_perception_msgs::DetectionArr
 	// publish face positions
 	ros::Time image_recording_time = (face_position_msg_in->detections.size() > 0 ? face_position_msg_in->detections[0].header.stamp : ros::Time(0));
 	cob_perception_msgs::DetectionArray face_position_msg_out;
-	prepareFacePositionMessage(face_position_msg_out, image_recording_time);
-	face_position_msg_out.header.stamp = face_position_msg_in->header.stamp;
+	prepareFacePositionMessage(face_position_msg_out, image_recording_time, face_position_msg_in->detections[0].header.frame_id);
+	face_position_msg_out.header = face_position_msg_in->header;
 	face_position_publisher_.publish(face_position_msg_out);
 
 	//  // display

--- a/cob_people_detection/ros/src/detection_tracker_node.cpp
+++ b/cob_people_detection/ros/src/detection_tracker_node.cpp
@@ -262,7 +262,7 @@ unsigned long DetectionTrackerNode::copyDetection(const cob_perception_msgs::Det
 	// else dest.detector = src.detector;
 	dest.detector = src.detector;
 
-	dest.header.stamp = src.header.stamp; //ros::Time::now();
+	dest.header = src.header; //ros::Time::now();
 
 	return ipa_Utils::RET_OK;
 }
@@ -377,7 +377,7 @@ unsigned long DetectionTrackerNode::prepareFacePositionMessage(cob_perception_ms
 	//      	  if (face_position_msg_out.detections[i].label=="Unknown")
 	//      		  face_position_msg_out.detections[i].label = "0000";
 	//        }
-	face_position_msg_out.header.stamp = ros::Time::now();
+	face_position_msg_out.header.stamp = image_recording_time;
 
 	return ipa_Utils::RET_OK;
 }
@@ -606,7 +606,7 @@ void DetectionTrackerNode::inputCallback(const cob_perception_msgs::DetectionArr
 					std::cout << "\n***** New detection *****\n\n";
 				cob_perception_msgs::Detection det_out;
 				copyDetection(det_in, det_out, false);
-				det_out.pose.header.frame_id = face_position_msg_in->header.frame_id;
+				det_out.pose.header = face_position_msg_in->header;
 				face_position_accumulator_.push_back(det_out);
 				// remember label history
 				std::map<std::string, double> new_identification_data;
@@ -624,7 +624,7 @@ void DetectionTrackerNode::inputCallback(const cob_perception_msgs::DetectionArr
 	removeMultipleInstancesOfLabel();
 
 	// publish face positions
-	ros::Time image_recording_time = (face_position_msg_in->detections.size() > 0 ? face_position_msg_in->detections[0].header.stamp : ros::Time::now());
+	ros::Time image_recording_time = (face_position_msg_in->detections.size() > 0 ? face_position_msg_in->detections[0].header.stamp : ros::Time(0));
 	cob_perception_msgs::DetectionArray face_position_msg_out;
 	prepareFacePositionMessage(face_position_msg_out, image_recording_time);
 	face_position_msg_out.header.stamp = face_position_msg_in->header.stamp;

--- a/cob_people_detection/ros/src/face_recognizer_node.cpp
+++ b/cob_people_detection/ros/src/face_recognizer_node.cpp
@@ -486,7 +486,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_perception_msgs::ColorD
 			// set label
 			det.label = "UnknownHead";
 			// set origin of detection
-			det.detector = ros::this_node::getName();
+			det.detector = "head";
 			// header
 			det.header = face_positions->header;
 			// add to message
@@ -518,7 +518,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_perception_msgs::ColorD
 				// set label
 				det.label = identification_labels[head][face];
 				// set origin of detection
-				det.detector = ros::this_node::getName();
+				det.detector = "face";
 				// header
 				det.header = face_positions->header;
 				// add to message

--- a/cob_people_detection/ros/src/face_recognizer_node.cpp
+++ b/cob_people_detection/ros/src/face_recognizer_node.cpp
@@ -486,7 +486,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_perception_msgs::ColorD
 			// set label
 			det.label = "UnknownHead";
 			// set origin of detection
-			det.detector = "head";
+			det.detector = ros::this_node::getName();
 			// header
 			det.header = face_positions->header;
 			// add to message
@@ -518,7 +518,7 @@ void FaceRecognizerNode::facePositionsCallback(const cob_perception_msgs::ColorD
 				// set label
 				det.label = identification_labels[head][face];
 				// set origin of detection
-				det.detector = "face";
+				det.detector = ros::this_node::getName();
 				// header
 				det.header = face_positions->header;
 				// add to message

--- a/cob_people_detection/ros/src/head_detector_node.cpp
+++ b/cob_people_detection/ros/src/head_detector_node.cpp
@@ -164,10 +164,12 @@ void HeadDetectorNode::pointcloud_callback(const sensor_msgs::PointCloud2::Const
 		cv_ptr.image = depth_patch;
 		cv_ptr.encoding = sensor_msgs::image_encodings::TYPE_32FC3; // CV32FC3
 		image_array.head_detections[i].depth_image = *(cv_ptr.toImageMsg());
+		image_array.head_detections[i].depth_image.header = pointcloud->header;
 		cv::Mat color_patch = color_image(head_bounding_boxes[i]);
 		cv_ptr.image = color_patch;
 		cv_ptr.encoding = sensor_msgs::image_encodings::BGR8;
 		image_array.head_detections[i].color_image = *(cv_ptr.toImageMsg());
+		image_array.head_detections[i].color_image.header = pointcloud->header;
 	}
 	head_position_publisher_.publish(image_array);
 

--- a/cob_people_detection/ros/src/obsolete/face_detection.cpp
+++ b/cob_people_detection/ros/src/obsolete/face_detection.cpp
@@ -1276,13 +1276,10 @@ void CobFaceDetectionNodelet::recognizeCallback(const sensor_msgs::PointCloud2::
 	//std::cout << "\t ... Recognize Time: " << (timeGetTime() - start) << std::endl;
 
 	// publish face positions
-	std::stringstream ss;
-	ss << depth_image.rows << " " << depth_image.cols;
 	cob_perception_msgs::DetectionArray facePositionMsg;
 	// image dimensions
-	facePositionMsg.header.frame_id = ss.str();
 	// time stamp
-	facePositionMsg.header.stamp = ros::Time::now(); //color_image_msg->header.stamp;  //
+	facePositionMsg.header.stamp = shared_image_msg->header.stamp;
 	//facePositionMsg.detections.reserve(color_faces_.size());
 	// add all range faces that do not contain a face detection in the color image
 	for (int i = 0; i < (int)range_faces_.size(); i++)
@@ -1294,6 +1291,7 @@ void CobFaceDetectionNodelet::recognizeCallback(const sensor_msgs::PointCloud2::
 
 			// 2D image coordinates
 			cob_perception_msgs::Detection det;
+			det.header = shared_image_msg->header;
 			det.mask.roi.x = face.x;
 			det.mask.roi.y = face.y;
 			det.mask.roi.width = face.width;


### PR DESCRIPTION
- fix detector name to reflect nodename (necessary for multiple detector setup)
- fill empty headers with content (stamp and frame_id) from input message

@ipa-rmb: please review
