### PR TITLE
Fix segfault from tracked_users_ initialization

### DIFF
--- a/cob_openni2_tracker/ros/src/body_tracker.cpp
+++ b/cob_openni2_tracker/ros/src/body_tracker.cpp
@@ -108,7 +108,7 @@ using namespace message_filters;
  * advertises subscribes and publishes.
  */
 BodyTracker::BodyTracker(ros::NodeHandle nh_priv)
-:pcl_cloud_(new pcl::PointCloud<pcl::PointXYZRGB>), m_poseUser(0), br_(), nh_(nh_priv)
+:pcl_cloud_(new pcl::PointCloud<pcl::PointXYZRGB>), tracked_users_(new list<nite::UserData>()), m_poseUser(0), br_(), nh_(nh_priv)
 {
 	marker_id_ = 0;
 
@@ -165,8 +165,6 @@ BodyTracker::BodyTracker(ros::NodeHandle nh_priv)
 	image_sub_.registerCallback(boost::bind(&BodyTracker::imageCallback, this, _1));
 	image_sub_.subscribe(*it_, "/camera/rgb/image_raw", 1);
 	image_pub_ = it_->advertise("colorimage_out", 1);
-
-	tracked_users_ = new list<nite::UserData>();
 }
 
 
@@ -314,10 +312,6 @@ void BodyTracker::runTracker()
 {
 	while(nh_.ok())
 	{
-		if(tracked_users_ == NULL)
-		{
-			tracked_users_ = new list<nite::UserData>();
-		}
 		nite::UserTrackerFrameRef userTrackerFrame;
 		openni::VideoFrameRef depthFrame;
 


### PR DESCRIPTION
tracked_users_ has to be initialized before registering the
imageCallback, otherwise it can be NULL inside the callback,
leading to the following segfault:

```
#0  0x00007fffec52419a in std::list<nite::UserData, std::allocator<nite::UserData> >::empty (this=0x0) at /usr/include/c++/4.8/bits/stl_list.h:869
#1  0x00007fffec515161 in BodyTracker::imageCallback (this=0x95c090, color_image_msg=...)
    at /home/martin/ros-indigo-ws/src/cob_people_perception/cob_openni2_tracker/ros/src/body_tracker.cpp:196
```
