### PR TITLE
various fixes

### DIFF
--- a/cob_people_detection/CMakeLists.txt
+++ b/cob_people_detection/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(catkin REQUIRED COMPONENTS
 	${catkin_BUILD_PACKAGES}
 )
 
-find_package(Boost REQUIRED COMPONENTS signals system filesystem)
+find_package(Boost REQUIRED COMPONENTS system filesystem)
 find_package(OpenCV REQUIRED)
 #find_package(orocos_kdl REQUIRED)
 #find_package(PCL REQUIRED)

--- a/cob_people_detection/common/src/munkres/munkres.cpp
+++ b/cob_people_detection/common/src/munkres/munkres.cpp
@@ -572,12 +572,8 @@ bool munkres::step5(int r, int c)
 	//create our sequence
 	while (!done)
 	{
-		switch (looking_for_star)
+		if (looking_for_star)
 		{
-
-		//if we're looking for a star
-		case true:
-
 			//special case protection
 			a = r;
 
@@ -611,11 +607,9 @@ bool munkres::step5(int r, int c)
 			//we can't do this earlier due to needing to check for stars in the column
 			//mark the column as starred
 			column_starred[c] = true;
-			break;
-
-			//if we're looking for a prime
-		case false:
-
+		}
+		else
+		{
 			//prime current index
 			cell_array[r][c].primed = false;
 			//unstar current index
@@ -630,7 +624,6 @@ bool munkres::step5(int r, int c)
 
 			//set case to look for star next
 			looking_for_star = true;
-			break;
 		}
 	}
 


### PR DESCRIPTION
 1. same as https://github.com/ipa320/cob_driver/pull/406
 2. fixes `-Wswitch-bool` warning
   ```
   Warnings   << cob_people_detection:make /root/catkin_ws/logs/cob_people_detection/build.make.000.log

   /root/catkin_ws/src/cob_people_perception/cob_people_detection/common/src/munkres/munkres.cpp: In member function ‘bool munkres::step5(int, int)’:

   /root/catkin_ws/src/cob_people_perception/cob_people_detection/common/src/munkres/munkres.cpp:575:27: warning: switch condition has type bool [-Wswitch-bool]

   switch (looking_for_star)

                           ^
   
   cd /root/catkin_ws/build/cob_people_detection; catkin build --get-env cob_people_detection | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
   ```

